### PR TITLE
Open new file instead of appending to existing one

### DIFF
--- a/SD_Card.h
+++ b/SD_Card.h
@@ -9,11 +9,13 @@
 class SDCard {
   private:
     File m_sdCardFile;
+    char m_fileName[13]; // 12 characters + null terminator
     bool m_begun; // SPI communications have been established
     bool m_proven; // The self-test passed
 
     static const int M_CHIP_SELECT = SDCARD_SS_PIN;
-    static constexpr const char* M_FILE_NAME = "CAPS_INF.CSV";
+    static constexpr const char* M_FILE_NAME = "CAPS_INF";
+    static constexpr const char* M_FILE_EXT = ".CSV";
 
     static constexpr const char* M_HEADERS =
       "Latitude,Longitude,Altitude (MSL),Satellites,Timestamp,Accel X,Accel Y,Accel Z,Altitude (AGL),"
@@ -23,6 +25,38 @@ class SDCard {
       "VOC Reading,Humidity,Temperature,"
 #endif
       "Gyro X,Gyro Y,Gyro Z";
+
+    // Finds an available filename and sets m_fileName accordingly.
+    void findFileName() {
+      // First, check if the base file name is available
+      strcpy(m_fileName, M_FILE_NAME);
+      strcat(m_fileName, M_FILE_EXT);
+      if (!SD.exists(m_fileName)) {
+        return;
+      }
+
+      // Then, try it with numbers
+      const size_t BASENAME_LENGTH = strlen(M_FILE_NAME);
+      for (int i = 0; i <= 99999999; ++i) {
+        // Convert the number to a C-style string (= char[])
+        char buf[9];
+        sprintf(buf, "%d", i);
+        // Overwrite just the end of the filename with the number
+        // e.g. CAPS_INF + 13 => CAPS_I13
+        size_t bufLen = strlen(buf);
+        memcpy(m_fileName + BASENAME_LENGTH - bufLen, buf, bufLen);
+        if (!SD.exists(m_fileName)) {
+          return;
+        }
+      }
+
+      // We're out of filenames, somehow...
+      // Do we really have a hundred million files?
+      // Whatever, reset to the default and delete the file
+      strcpy(m_fileName, M_FILE_NAME);
+      strcat(m_fileName, M_FILE_EXT);
+      SD.remove(m_fileName);
+    }
 
     // Write some random data to a file and see if we can read it back
     bool selfTest() {
@@ -78,13 +112,13 @@ class SDCard {
       randomFile.close();
       // If the data file was open before, re-open it
       if (open) {
-        m_sdCardFile = SD.open(M_FILE_NAME, FILE_WRITE);
+        m_sdCardFile = SD.open(m_fileName, FILE_WRITE);
       }
 
       return !areDifferent;
     }
   public:
-    SDCard() : m_sdCardFile(), m_begun(false), m_proven(false) {}
+    SDCard() : m_sdCardFile(), m_fileName{0}, m_begun(false), m_proven(false) {}
 
     enum Status {
       /** SPI communications have not yet been established. */
@@ -180,11 +214,9 @@ class SDCard {
       }
 
       if (m_proven && !m_sdCardFile) {
-        bool alreadyExists = SD.exists(M_FILE_NAME);
-        m_sdCardFile = SD.open(M_FILE_NAME, FILE_WRITE);
-        // If the file is being created by this action, we need to create headers
-        // If the file already exists, assume it already has headers.
-        if ((bool)m_sdCardFile && !alreadyExists) {
+        findFileName();
+        m_sdCardFile = SD.open(m_fileName, FILE_WRITE);
+        if (m_sdCardFile) {
           m_sdCardFile.println(M_HEADERS);
         }
       }


### PR DESCRIPTION
This PR adds support for having multiple files rather than appending to the same file. In order to work with the 8.3 filename convention, it truncates the base filename (the part before the `.`) when appending the number.