### PR TITLE
Add sync word

### DIFF
--- a/sketch_oct9a.ino
+++ b/sketch_oct9a.ino
@@ -1,4 +1,4 @@
-#if false
+#if true
 
 #include "wiring_private.h"
 #include "Scheduler.h"
@@ -21,6 +21,8 @@
 // If this is more than ~18, some packets will have outdated GPS info.
 // If this is more than ~200, the radio will be rate-limited by the sensors.
 const unsigned long RADIO_FREQ = 144;
+
+const byte SYNC_WORD[] = { 0xF2, 0x67, 0x0D, 0x98 };
 
 Altimeter alt;
 volatile float last_alt;
@@ -254,9 +256,7 @@ void radio_loop() {
 #endif
   );
 
-  // In theory, this should send the data to the radio.
-  // In practice, this is completely untested. If nothing is connected to the UART pins, however,
-  // this doesn't do anything, so it's harmless to leave in for now.
+  Serial1.write(SYNC_WORD, sizeof SYNC_WORD);
   Serial1.write(
     (char*)&f,
     FRAME_SIZE()


### PR DESCRIPTION
As per @billycp2722, the radio needs to send a "sync word" between packets. I explained this particular choice of sync word in the Discord server.